### PR TITLE
Add user watchlist feature and tests

### DIFF
--- a/backend/app/controllers/watchlistController.py
+++ b/backend/app/controllers/watchlistController.py
@@ -1,0 +1,53 @@
+# backend/app/controllers/watchlistController.py
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from backend.app.dependencies import get_current_user
+from backend.app.services.watchlistService import watchlist_service
+
+router = APIRouter(
+    prefix="/watchlist",
+    tags=["watchlist"],
+)
+
+
+@router.get("")
+def get_my_watchlist(current_user: dict = Depends(get_current_user)):
+    """
+    Return the current user's watchlist.
+    """
+    try:
+        items = watchlist_service.get_watchlist(current_user["username"])
+        return {"watchlist": items}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/{movieTitle}")
+def add_to_my_watchlist(
+    movieTitle: str,
+    current_user: dict = Depends(get_current_user),
+):
+    """
+    Add a movie to the current user's watchlist.
+    """
+    try:
+        items = watchlist_service.add_movie(current_user["username"], movieTitle)
+        return {"message": "Movie added to watchlist", "watchlist": items}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.delete("/{movieTitle}")
+def remove_from_my_watchlist(
+    movieTitle: str,
+    current_user: dict = Depends(get_current_user),
+):
+    """
+    Remove a movie from the current user's watchlist.
+    """
+    try:
+        items = watchlist_service.remove_movie(current_user["username"], movieTitle)
+        return {"message": "Movie removed from watchlist", "watchlist": items}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,7 +3,7 @@ from .controllers.movieController import router as movie_router
 from .controllers.authController import router as auth_router
 from .controllers.reviewController import router as review_router
 from .controllers.moderationController import router as moderation_router
-
+from backend.app.controllers.watchlistController import router as watchlist_router
 
 app = FastAPI(title="Rotton Eggs Movie Review System")
 
@@ -12,3 +12,4 @@ app.include_router(movie_router)
 app.include_router(auth_router)
 app.include_router(review_router)
 app.include_router(moderation_router)
+app.include_router(watchlist_router) 

--- a/backend/app/services/watchlistService.py
+++ b/backend/app/services/watchlistService.py
@@ -1,0 +1,57 @@
+
+import os
+from typing import List
+
+from backend.app.repositories import usersRepo
+
+IMDB_ROOT = os.path.join("data", "imdb")
+
+
+def _assert_movie_exists(movie_title: str) -> None:
+    """
+    Ensure that the given movieTitle exists under data/imdb/<MovieTitle>/movieReviews.csv.
+
+    Raises:
+        ValueError: if the movie cannot be found in the imdb folder structure.
+    """
+    # basic sanity
+    if not movie_title or movie_title.strip() == "":
+        raise ValueError("Movie title cannot be empty")
+
+    folder = os.path.join(IMDB_ROOT, movie_title)
+    csv_path = os.path.join(folder, "movieReviews.csv")
+
+    if not os.path.exists(csv_path):
+        raise ValueError("Movie not found in IMDb dataset")
+
+
+class WatchlistService:
+    """
+    Service layer for user watchlists.
+    """
+
+    def get_watchlist(self, username: str) -> List[str]:
+        return usersRepo.get_watchlist(username)
+
+    def add_movie(self, username: str, movie_title: str) -> List[str]:
+        """
+        Add a movie to the user's watchlist.
+
+        - Rejects empty titles.
+        - Rejects movies that are not present in data/imdb/<MovieTitle>/movieReviews.csv.
+        """
+        _assert_movie_exists(movie_title)
+        return usersRepo.add_to_watchlist(username, movie_title)
+
+    def remove_movie(self, username: str, movie_title: str) -> List[str]:
+        """
+        Remove a movie from the user's watchlist.
+
+        - Still enforces that the movie must be a valid IMDb movie,
+          so users cannot add/remove arbitrary fake names.
+        """
+        _assert_movie_exists(movie_title)
+        return usersRepo.remove_from_watchlist(username, movie_title)
+
+
+watchlist_service = WatchlistService()

--- a/data/users.json
+++ b/data/users.json
@@ -11,7 +11,10 @@
     "passwordHash": "$2b$12$MAUZ8Rjgy0fr7oyST/Htm.891FVrJGPeXIhbRZnScBT/oD81/4l92",
     "role": "user",
     "penalties": 0,
-    "watchlist": []
+    "watchlist": [
+      "Joker",
+      "Avengers Endgame"
+    ]
   },
   {
     "userName": "testuser",

--- a/tests/test_watchlist.py
+++ b/tests/test_watchlist.py
@@ -1,0 +1,128 @@
+# tests/test_watchlist.py
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from backend.app.main import app
+
+client = TestClient(app)
+
+
+# ---------- GET watchlist ----------
+
+@patch("backend.app.dependencies.find_user_by_username")
+@patch("backend.app.repositories.usersRepo.get_watchlist")
+def test_get_my_watchlist(mock_get_watchlist, mock_find_user):
+    mock_find_user.return_value = {
+        "userName": "alice",
+        "passwordHash": "x",
+        "role": "user",
+        "penalties": 0,
+        "watchlist": ["Joker"],
+        "banExpiresAt": None,
+    }
+    mock_get_watchlist.return_value = ["Joker"]
+
+    resp = client.get("/watchlist", headers={"X-Username": "alice"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["watchlist"] == ["Joker"]
+    mock_get_watchlist.assert_called_once_with("alice")
+
+
+# ---------- POST watchlist (valid movie) ----------
+
+@patch("backend.app.dependencies.find_user_by_username")
+@patch("backend.app.repositories.usersRepo.add_to_watchlist")
+@patch("backend.app.services.watchlistService.os.path.exists", return_value=True)
+def test_add_to_my_watchlist_valid_movie(mock_exists, mock_add, mock_find_user):
+    mock_find_user.return_value = {
+        "userName": "alice",
+        "passwordHash": "x",
+        "role": "user",
+        "penalties": 0,
+        "watchlist": [],
+        "banExpiresAt": None,
+    }
+    mock_add.return_value = ["Joker"]
+
+    resp = client.post("/watchlist/Joker", headers={"X-Username": "alice"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["message"] == "Movie added to watchlist"
+    assert body["watchlist"] == ["Joker"]
+    mock_exists.assert_called()  # ensure existence was checked
+    mock_add.assert_called_once_with("alice", "Joker")
+
+
+# ---------- POST watchlist (invalid / non-existent movie) ----------
+
+@patch("backend.app.dependencies.find_user_by_username")
+@patch("backend.app.services.watchlistService.os.path.exists", return_value=False)
+def test_add_to_my_watchlist_invalid_movie(mock_exists, mock_find_user):
+    mock_find_user.return_value = {
+        "userName": "alice",
+        "passwordHash": "x",
+        "role": "user",
+        "penalties": 0,
+        "watchlist": [],
+        "banExpiresAt": None,
+    }
+
+    resp = client.post("/watchlist/FakeMovie", headers={"X-Username": "alice"})
+
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["detail"] == "Movie not found in IMDb dataset"
+    mock_exists.assert_called()
+
+
+# ---------- DELETE watchlist (valid movie) ----------
+
+@patch("backend.app.dependencies.find_user_by_username")
+@patch("backend.app.repositories.usersRepo.remove_from_watchlist")
+@patch("backend.app.services.watchlistService.os.path.exists", return_value=True)
+def test_remove_from_my_watchlist_valid_movie(mock_exists, mock_remove, mock_find_user):
+    mock_find_user.return_value = {
+        "userName": "alice",
+        "passwordHash": "x",
+        "role": "user",
+        "penalties": 0,
+        "watchlist": ["Joker"],
+        "banExpiresAt": None,
+    }
+    mock_remove.return_value = []
+
+    resp = client.delete("/watchlist/Joker", headers={"X-Username": "alice"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["message"] == "Movie removed from watchlist"
+    assert body["watchlist"] == []
+    mock_exists.assert_called()
+    mock_remove.assert_called_once_with("alice", "Joker")
+
+
+# ---------- DELETE watchlist (invalid / non-existent movie) ----------
+
+@patch("backend.app.dependencies.find_user_by_username")
+@patch("backend.app.services.watchlistService.os.path.exists", return_value=False)
+def test_remove_from_my_watchlist_invalid_movie(mock_exists, mock_find_user):
+    mock_find_user.return_value = {
+        "userName": "alice",
+        "passwordHash": "x",
+        "role": "user",
+        "penalties": 0,
+        "watchlist": ["Joker"],
+        "banExpiresAt": None,
+    }
+
+    resp = client.delete("/watchlist/FakeMovie", headers={"X-Username": "alice"})
+
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["detail"] == "Movie not found in IMDb dataset"
+    mock_exists.assert_called()


### PR DESCRIPTION

This PR adds a per-user watchlist feature to RottenEggs, with validation so users can only add movies that actually exist in the local IMDb dataset (data/imdb/<MovieTitle>/movieReviews.csv). All tests pass (pytest -vv).

Summary
	•	Users now have a watchlist: List[str] field stored in data/users.json.
	•	New watchlist API:
	•	GET /watchlist – get current user’s watchlist.
	•	POST /watchlist/{movieTitle} – add a movie.
	•	DELETE /watchlist/{movieTitle} – remove a movie.
	•	Only movies that exist under data/imdb/<MovieTitle>/movieReviews.csv are allowed:
	•	If the CSV file doesn’t exist, the request fails with 400 and detail: "Movie not found in IMDb dataset".

Implementation
	•	User model extended with watchlist (keeps existing fields like penalties, banExpiresAt).
	•	usersRepo:
	•	get_watchlist(username)
	•	add_to_watchlist(username, movie_title)
	•	remove_from_watchlist(username, movie_title)
	•	update_user_record(updated_user)
	•	WatchlistService:
	•	Validates movie existence via os.path.exists("data/imdb/<movieTitle>/movieReviews.csv").
	•	Rejects empty or non-existent movie titles with ValueError.
	•	watchlistController:
	•	Uses get_current_user and delegates to WatchlistService.
	•	Converts ValueError into HTTPException(status_code=400, detail=str(e)).
	•	main.py updated to include the watchlist router.

Tests
	•	New tests/test_watchlist.py:
	•	GET: returns user’s watchlist.
	•	POST valid movie: 200, added to watchlist (with os.path.exists patched to True).
	•	POST invalid movie: 400, “Movie not found in IMDb dataset”.
	•	DELETE valid movie: 200, removed from watchlist.
	•	DELETE invalid movie: 400, same error message.

All existing and new tests pass.